### PR TITLE
fix: remove frappe as a requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-frappe
+# frappe   # https://github.com/frappe/frappe is installed during bench-init
 sentry-sdk


### PR DESCRIPTION
For Python3.7+ compatibility.

With its new dependency resolver, pip tries to first install `frappe` using pypi, which exists but doesn't belong to Frappe Tech. This causes installation to fail.

**Ref:** https://github.com/frappe/erpnext/pull/25501